### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Geodesi
+version: 3.0
+organization: Geodesi
+product: Geodesiverktøy
+repo_types: [Tool]
+platforms: [LOKALT]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "geokassa"
+  tags:
+  - "private"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "geodesi_devops"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_geokassa"
+  title: "Security Champion geokassa"
+spec:
+  type: "security_champion"
+  parent: "geodesi_security_champions"
+  members:
+  - "himsve"
+  children:
+  - "resource:geokassa"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "geokassa"
+  links:
+  - url: "https://github.com/kartverket/geokassa"
+    title: "geokassa på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_geokassa"
+  dependencyOf:
+  - "component:geokassa"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Geodesi`
- `product: Geodesiverktøy`
- `repo_types: [Tool]`
- `platforms: [LOKALT]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.